### PR TITLE
Remove unused & broken robot_sufix parameter

### DIFF
--- a/launch/move_group.launch
+++ b/launch/move_group.launch
@@ -30,12 +30,10 @@
   </include>
 
   <!-- Trajectory Execution Functionality -->
-  <arg name="robot_sufix"  default=""/>
   <include ns="move_group" file="$(find tiago_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="moveit_controller_manager" value="tiago" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
-    <arg name="robot_sufix" value="$(arg robot_sufix)" />
   </include>
 
   <!-- Sensors Functionality -->

--- a/launch/trajectory_execution.launch.xml
+++ b/launch/trajectory_execution.launch.xml
@@ -14,9 +14,7 @@
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="tiago" />
-  <arg name="robot_sufix"  default=""/>
   <include file="$(find tiago_moveit_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
-    <arg name="robot_sufix" value="$(arg robot_sufix)" />
   </include>
   
 </launch>


### PR DESCRIPTION
` roslaunch tiago_moveit_config demo.launch ` was broken with 

`unused args [robot_sufix] for include of [/home/bence/moveit_ws/src/tiago_moveit_config/launch/fake_moveit_controller_manager.launch.xml]`
and 
`unused args [robot_sufix] for include of [/home/bence/moveit_ws/src/tiago_moveit_config/launch/trajectory_execution.launch.xml]`

I haven't touched `robot_sufix` in `launch/tiago_moveit_controller_manager.launch.xml` but I'd recommend sorting it's name out as it's inconsistent with the `robot` argument used in this and other packages.