### PR TITLE
Remove arm

### DIFF
--- a/launch/move_group.launch.py
+++ b/launch/move_group.launch.py
@@ -66,14 +66,10 @@ def launch_setup(context, *args, **kwargs):
         'wrist_model': wrist_model,
     }
 
-    robot_description_semantic = ('config/srdf/tiago_' + get_tiago_hw_suffix(
-        arm=arm, wrist_model=None, end_effector=end_effector, ft_sensor=ft_sensor) + '.srdf')
+    robot_description_semantic = ('config/srdf/tiago_no-arm_no-end-effector_no-ft-sensor.srdf')
 
     # Trajectory Execution Functionality
-    moveit_simple_controllers_path = (
-        'config/controllers/controllers_' +
-        get_tiago_hw_suffix(arm=arm, wrist_model=None,
-                            end_effector=end_effector, ft_sensor=ft_sensor) + '.yaml')
+    moveit_simple_controllers_path = ('config/controllers/controllers_no-arm_no-end-effector_no-ft-sensor.yaml')
 
     planning_scene_monitor_parameters = {
         'publish_planning_scene': True,


### PR DESCRIPTION
move_group.launch.py does not find the variables when we select no-arm, no-end-effector_ and no-ft-sensor, then the srdf path is not created correctly